### PR TITLE
Replace Notion-rendered home page with native static page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a personal home page built with Next.js that renders content from Notion and remote Markdown files. The site is hosted at timsam.au and deployed on Vercel. AWS infrastructure (CDK) provides a table of contents API backed by DynamoDB.
+This is a personal home page built with Next.js. The home page is a native static React page; additional routes render remote Markdown files and PDFs. The site is hosted at timsam.au and deployed on Vercel. AWS infrastructure (CDK) provides a table of contents API backed by DynamoDB.
 
 ## Development Commands
 
@@ -38,10 +38,10 @@ npx ts-node infrastructure/scripts/populate-toc.ts  # Populate TOC from existing
 
 The application uses Next.js Pages Router with four content rendering paths:
 
-1. **Notion-based home page** (`pages/index.tsx`)
-   - Fetches content from Notion API using the `PAGE_ID` environment variable
-   - Uses ISR (Incremental Static Regeneration) with 10-second revalidate
-   - Renders with `react-notion-x` library for Notion block rendering
+1. **Static home page** (`pages/index.tsx`)
+   - Plain React/JSX page with bio, links, side projects, work experience, skills, hackathons, and education
+   - No external data fetching — fully static and prerendered at build time
+   - Uses Tailwind `prose` styling for typography
 
 2. **Markdown rendering** (`pages/[...name].tsx`)
    - Catch-all route for dynamic markdown content (e.g., `/blog/post-name`)
@@ -79,7 +79,6 @@ The CDK stack has its own `package.json` and `tsconfig.json`. Run `npm install` 
 ### Environment Variables
 
 Required in `.env` file:
-- `PAGE_ID` - Notion page ID for the home page
 - `MD_SOURCE_URL` - Base URL for fetching remote markdown files (format: `domain.com/path`)
 - `PDF_SOURCE_URL` - Base URL for fetching PDF files (format: `domain.com/path`)
 - `TOC_API_URL` - API Gateway endpoint for table of contents

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,4 @@ require("dotenv").config();
 
 module.exports = {
     reactStrictMode: true,
-    env: {
-        PAGE_ID: process.env.PAGE_ID,
-    },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,12 @@
             "name": "notion-x-example-full",
             "version": "6.16.2",
             "dependencies": {
-                "@notionhq/client": "^2.3.0",
                 "@vercel/speed-insights": "^1.3.1",
                 "dotenv": "^16.6.1",
                 "next": "^15.5.18",
                 "next-mdx-remote": "^6.0.0",
-                "notion-client": "^7.10.0",
-                "notion-utils": "^7.10.0",
                 "react": "^18.3.1",
-                "react-dom": "^18.3.1",
-                "react-notion-x": "^7.10.0"
+                "react-dom": "^18.3.1"
             },
             "devDependencies": {
                 "@next/bundle-analyzer": "^14.2.35",
@@ -78,19 +74,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/runtime": {
-            "version": "7.26.10",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
-            "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -109,11 +92,6 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
-        },
-        "node_modules/@fisch0920/medium-zoom": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@fisch0920/medium-zoom/-/medium-zoom-1.0.7.tgz",
-            "integrity": "sha512-hPUrgVM/QvsZdZzDTPyL1C1mOtEw03RqTLmK7ZlJ8S/64u4O4O5BvPvjB/9kyLtE6iVaS9UDRAMSwmM9uh2JIw=="
         },
         "node_modules/@img/colour": {
             "version": "1.0.0",
@@ -608,19 +586,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@matejmazur/react-katex": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@matejmazur/react-katex/-/react-katex-3.1.3.tgz",
-            "integrity": "sha512-rBp7mJ9An7ktNoU653BWOYdO4FoR4YNwofHZi+vaytX/nWbIlmHVIF+X8VFOn6c3WYmrLT5FFBjKqCZ1sjR5uQ==",
-            "engines": {
-                "node": ">=12",
-                "yarn": ">=1.1"
-            },
-            "peerDependencies": {
-                "katex": ">=0.9",
-                "react": ">=16"
-            }
-        },
         "node_modules/@mdx-js/mdx": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.0.1.tgz",
@@ -858,19 +823,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@notionhq/client": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.3.0.tgz",
-            "integrity": "sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node-fetch": "^2.5.10",
-                "node-fetch": "^2.6.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -981,18 +933,10 @@
             "version": "20.19.41",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
             "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
-            }
-        },
-        "node_modules/@types/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-lX17GZVpJ/fuCjguZ5b3TjEbSENxmEk1B2z02yoXSK9WMEWRivhdSY73wWMn6bpcCDAOh6qAdktpKHIlkDk2lg==",
-            "dependencies": {
-                "@types/node": "*",
-                "form-data": "^4.0.0"
             }
         },
         "node_modules/@types/prop-types": {
@@ -1138,11 +1082,6 @@
                 "astring": "bin/astring"
             }
         },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
         "node_modules/autoprefixer": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
@@ -1195,27 +1134,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.30",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
@@ -1239,18 +1157,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
             }
         },
         "node_modules/brace-expansion": {
@@ -1309,44 +1215,6 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
-        "node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/camelcase-css": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1375,21 +1243,6 @@
                 }
             ],
             "license": "CC-BY-4.0"
-        },
-        "node_modules/canvas": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.1.0.tgz",
-            "integrity": "sha512-tTj3CqqukVJ9NgSahykNwtGda7V33VLObwrHfzT0vqJXu7J4d4C/7kQQW3fOEGDfZZoILPut5H00gOjyttPGyg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "node-addon-api": "^7.0.0",
-                "prebuild-install": "^7.1.1"
-            },
-            "engines": {
-                "node": "^18.12.0 || >= 20.9.0"
-            }
         },
         "node_modules/ccount": {
             "version": "2.0.1",
@@ -1536,28 +1389,11 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "license": "ISC",
-            "optional": true
-        },
         "node_modules/client-only": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
             "license": "MIT"
-        },
-        "node_modules/clsx": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/collapse-white-space": {
             "version": "2.1.0",
@@ -1586,17 +1422,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -1604,14 +1429,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-            "engines": {
-                "node": ">= 12"
             }
         },
         "node_modules/cross-env": {
@@ -1736,40 +1553,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/dequal": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1777,12 +1560,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/destr": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
-            "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-            "license": "MIT"
         },
         "node_modules/detect-libc": {
             "version": "2.1.0",
@@ -1830,20 +1607,6 @@
                 "url": "https://dotenvx.com"
             }
         },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/duplexer": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -1868,61 +1631,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true
-        },
-        "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/escalade": {
             "version": "3.2.0",
@@ -2013,28 +1721,6 @@
                 "@types/estree": "^1.0.0"
             }
         },
-        "node_modules/eventemitter3": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-            "license": "MIT"
-        },
-        "node_modules/exenv": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-            "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "license": "(MIT OR WTFPL)",
-            "optional": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2111,22 +1797,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/fraction.js": {
             "version": "5.3.4",
             "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -2139,13 +1809,6 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/rawify"
             }
-        },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -2165,53 +1828,10 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/glob": {
             "version": "10.5.0",
@@ -2245,18 +1865,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/gzip-size": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -2272,37 +1880,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -2393,41 +1975,6 @@
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
-        },
-        "node_modules/ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "BSD-3-Clause",
-            "optional": true
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "license": "ISC",
-            "optional": true
         },
         "node_modules/inline-style-parser": {
             "version": "0.1.1",
@@ -2565,17 +2112,6 @@
                 "@types/estree": "*"
             }
         },
-        "node_modules/is-url-superb": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-6.1.0.tgz",
-            "integrity": "sha512-LXdhGlYqUPdvEyIhWPEEwYYK3yrUiPcBjmFGlZNv1u5GtIL5qQRf7ddDyPNAvsMFqdzS923FROpTQU97tLe3JQ==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2614,21 +2150,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-        },
-        "node_modules/katex": {
-            "version": "0.16.21",
-            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.21.tgz",
-            "integrity": "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==",
-            "funding": [
-                "https://opencollective.com/katex",
-                "https://github.com/sponsors/katex"
-            ],
-            "dependencies": {
-                "commander": "^8.3.0"
-            },
-            "bin": {
-                "katex": "cli.js"
-            }
         },
         "node_modules/lilconfig": {
             "version": "3.1.3",
@@ -2677,26 +2198,6 @@
                 "node": "14 || >=16.14"
             }
         },
-        "node_modules/make-cancellable-promise": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-1.3.2.tgz",
-            "integrity": "sha512-GCXh3bq/WuMbS+Ky4JBPW1hYTOU+znU+Q5m9Pu+pI8EoUqIHk9+tviOKC6/qhHh8C4/As3tzJ69IF32kdz85ww==",
-            "license": "MIT",
-            "optional": true,
-            "funding": {
-                "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
-            }
-        },
-        "node_modules/make-event-props": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.6.2.tgz",
-            "integrity": "sha512-iDwf7mA03WPiR8QxvcVHmVWEPfMY1RZXerDVNCRYW7dUr2ppH3J58Rwb39/WG39yTZdRSxr3x+2v22tvI0VEvA==",
-            "license": "MIT",
-            "optional": true,
-            "funding": {
-                "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
-            }
-        },
         "node_modules/markdown-extensions": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
@@ -2706,15 +2207,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/mdast-util-from-markdown": {
@@ -2875,39 +2367,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/memoize": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
-            "integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
-            "license": "MIT",
-            "dependencies": {
-                "mimic-function": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/memoize?sponsor=1"
-            }
-        },
-        "node_modules/merge-refs": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.3.0.tgz",
-            "integrity": "sha512-nqXPXbso+1dcKDpPCXvwZyJILz+vSLqGGOnDrYHQYE+B8n9JTCekVLC65AfCpR4ggVyA/45Y0iR9LDyS2iI+zA==",
-            "license": "MIT",
-            "optional": true,
-            "funding": {
-                "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
             }
         },
         "node_modules/merge2": {
@@ -3502,50 +2961,6 @@
                 "node": ">=8.6"
             }
         },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mimic-function": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/minimatch": {
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -3562,16 +2977,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "license": "MIT",
-            "optional": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/minipass": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -3580,13 +2985,6 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
-        },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/mrmime": {
             "version": "2.0.0",
@@ -3630,13 +3028,6 @@
             "engines": {
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
-        },
-        "node_modules/napi-build-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/next": {
             "version": "15.5.18",
@@ -3739,51 +3130,6 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
-        "node_modules/node-abi": {
-            "version": "3.74.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
-            "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/node-addon-api": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/node-fetch-native": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-            "license": "MIT"
-        },
         "node_modules/node-releases": {
             "version": "2.0.44",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
@@ -3800,61 +3146,11 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/normalize-url": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-            "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/notion-client": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/notion-client/-/notion-client-7.10.0.tgz",
-            "integrity": "sha512-Rb4/nR4vIRwIExvKiVhZKJEpGoE0IRFlHMKbs0tcZcecZaUVRzVAu7PHuaHC5ivSds26z497dxXYF3mnMrMt7g==",
-            "license": "MIT",
-            "dependencies": {
-                "notion-types": "7.10.0",
-                "notion-utils": "7.10.0",
-                "ofetch": "^1.4.1",
-                "p-map": "^7.0.3"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/notion-types": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/notion-types/-/notion-types-7.10.0.tgz",
-            "integrity": "sha512-t57RdnGnup7NcMGJkrlshe3gXaFYOj565NL1Q1l/MrZZ/K2xbHO06PtBXDEFTFYjvxQagU0NzKzaSNKocU9e4Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/notion-utils": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/notion-utils/-/notion-utils-7.10.0.tgz",
-            "integrity": "sha512-Z/L+xOzVWM5wBHOqLu3PwCzA/11yzVExMpR8FUcwHbS60DDULSgZgipXQBzKOlbQMnB+04BOkSGDNan+AxfxmA==",
-            "license": "MIT",
-            "dependencies": {
-                "is-url-superb": "^6.1.0",
-                "memoize": "^10.1.0",
-                "normalize-url": "^8.0.1",
-                "notion-types": "7.10.0",
-                "p-queue": "^8.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3868,27 +3164,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/ofetch": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
-            "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
-            "license": "MIT",
-            "dependencies": {
-                "destr": "^2.0.3",
-                "node-fetch-native": "^1.6.4",
-                "ufo": "^1.5.4"
-            }
-        },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/opener": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -3896,46 +3171,6 @@
             "dev": true,
             "bin": {
                 "opener": "bin/opener-bin.js"
-            }
-        },
-        "node_modules/p-map": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-            "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-queue": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
-            "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^5.0.1",
-                "p-timeout": "^6.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-timeout": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/package-json-from-dist": {
@@ -3997,30 +3232,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/path2d": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
-            "integrity": "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/pdfjs-dist": {
-            "version": "4.8.69",
-            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.8.69.tgz",
-            "integrity": "sha512-IHZsA4T7YElCKNNXtiLgqScw4zPd3pG9do8UrznC757gMd7UPeHSL2qwNNMJo4r79fl8oj1Xx+1nh2YkzdMpLQ==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "canvas": "^3.0.0-rc2",
-                "path2d": "^0.2.1"
             }
         },
         "node_modules/periscopic": {
@@ -4213,53 +3424,6 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
-        "node_modules/prebuild-install": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "detect-libc": "^2.0.0",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^2.0.0",
-                "node-abi": "^3.3.0",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^4.0.0",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            },
-            "bin": {
-                "prebuild-install": "bin.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/prismjs": {
-            "version": "1.30.0",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/prop-types": {
-            "version": "15.8.1",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.13.1"
-            }
-        },
         "node_modules/property-information": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
@@ -4267,17 +3431,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/pump": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-            "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
             }
         },
         "node_modules/queue-microtask": {
@@ -4299,22 +3452,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-            "optional": true,
-            "dependencies": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "bin": {
-                "rc": "cli.js"
-            }
         },
         "node_modules/react": {
             "version": "18.3.1",
@@ -4339,133 +3476,6 @@
                 "react": "^18.3.1"
             }
         },
-        "node_modules/react-fast-compare": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-            "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
-        },
-        "node_modules/react-hotkeys-hook": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.6.1.tgz",
-            "integrity": "sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==",
-            "peerDependencies": {
-                "react": ">=16.8.1",
-                "react-dom": ">=16.8.1"
-            }
-        },
-        "node_modules/react-image": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/react-image/-/react-image-4.1.0.tgz",
-            "integrity": "sha512-qwPNlelQe9Zy14K2pGWSwoL+vHsAwmJKS6gkotekDgRpcnRuzXNap00GfibD3eEPYu3WCPlyIUUNzcyHOrLHjw==",
-            "peerDependencies": {
-                "@babel/runtime": ">=7",
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
-            }
-        },
-        "node_modules/react-intersection-observer": {
-            "version": "9.16.0",
-            "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
-            "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "react-dom": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "license": "MIT"
-        },
-        "node_modules/react-lifecycles-compat": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-            "license": "MIT"
-        },
-        "node_modules/react-modal": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
-            "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
-            "license": "MIT",
-            "dependencies": {
-                "exenv": "^1.2.0",
-                "prop-types": "^15.7.2",
-                "react-lifecycles-compat": "^3.0.0",
-                "warning": "^4.0.3"
-            },
-            "peerDependencies": {
-                "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
-                "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
-            }
-        },
-        "node_modules/react-notion-x": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/react-notion-x/-/react-notion-x-7.10.0.tgz",
-            "integrity": "sha512-i5FZKruMoRESnx5Lqq1kTp8a/eseErQ3Ph93dKCoCeRRN9hnPGCxUdnu/wsBp5h2BHMqswRujDiclqZvoQE2IA==",
-            "license": "MIT",
-            "dependencies": {
-                "@fisch0920/medium-zoom": "^1.0.7",
-                "@matejmazur/react-katex": "^3.1.3",
-                "katex": "0.16.21",
-                "notion-types": "7.10.0",
-                "notion-utils": "7.10.0",
-                "prismjs": "^1.30.0",
-                "react-fast-compare": "^3.2.0",
-                "react-hotkeys-hook": "^4.5.1",
-                "react-image": "^4.0.3",
-                "react-intersection-observer": "^9.16.0",
-                "react-modal": "^3.16.3",
-                "unionize": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "react-pdf": "^9.2.1"
-            },
-            "peerDependencies": {
-                "react": ">=18",
-                "react-dom": ">=18"
-            }
-        },
-        "node_modules/react-pdf": {
-            "version": "9.2.1",
-            "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-9.2.1.tgz",
-            "integrity": "sha512-AJt0lAIkItWEZRA5d/mO+Om4nPCuTiQ0saA+qItO967DTjmGjnhmF+Bi2tL286mOTfBlF5CyLzJ35KTMaDoH+A==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "clsx": "^2.0.0",
-                "dequal": "^2.0.3",
-                "make-cancellable-promise": "^1.3.1",
-                "make-event-props": "^1.6.0",
-                "merge-refs": "^1.3.0",
-                "pdfjs-dist": "4.8.69",
-                "tiny-invariant": "^1.0.0",
-                "warning": "^4.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/read-cache": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4473,21 +3483,6 @@
             "dev": true,
             "dependencies": {
                 "pify": "^2.3.0"
-            }
-        },
-        "node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/readdirp": {
@@ -4501,13 +3496,6 @@
             "engines": {
                 "node": ">=8.10.0"
             }
-        },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/remark-mdx": {
             "version": "3.0.1",
@@ -4602,27 +3590,6 @@
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
-        },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
@@ -4721,53 +3688,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "decompress-response": "^6.0.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
-        },
         "node_modules/sirv": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -4797,16 +3717,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/string-width": {
@@ -4916,16 +3826,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/style-to-object": {
@@ -5040,36 +3940,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/tar-fs": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/thenify": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -5091,13 +3961,6 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/tiny-invariant": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5118,11 +3981,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "node_modules/trim-lines": {
             "version": "3.0.1",
@@ -5154,19 +4012,6 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/typescript": {
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5181,16 +4026,11 @@
                 "node": ">=14.17"
             }
         },
-        "node_modules/ufo": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-            "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-            "license": "MIT"
-        },
         "node_modules/undici-types": {
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
             "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/unified": {
@@ -5210,12 +4050,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
-        },
-        "node_modules/unionize": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/unionize/-/unionize-3.1.0.tgz",
-            "integrity": "sha512-LQZvbanzvpzvK0QYgRvnaA9VVe+g4nTbRlyoGGWDKFrZn0HJnDN5LC2Ti0+BxpKKOCrL3BQcRBVFPy/t12Y24Q==",
-            "license": "MIT"
         },
         "node_modules/unist-util-is": {
             "version": "6.0.0",
@@ -5344,7 +4178,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/vfile": {
             "version": "6.0.3",
@@ -5384,20 +4218,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
-        },
-        "node_modules/warning": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-            "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.0.0"
-            }
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "node_modules/webpack-bundle-analyzer": {
             "version": "4.10.1",
@@ -5445,15 +4265,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {
@@ -5561,13 +4372,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC",
-            "optional": true
         },
         "node_modules/ws": {
             "version": "7.5.10",

--- a/package.json
+++ b/package.json
@@ -13,16 +13,12 @@
         "deploy": "vercel deploy"
     },
     "dependencies": {
-        "@notionhq/client": "^2.3.0",
         "@vercel/speed-insights": "^1.3.1",
         "dotenv": "^16.6.1",
         "next": "^15.5.18",
         "next-mdx-remote": "^6.0.0",
-        "notion-client": "^7.10.0",
-        "notion-utils": "^7.10.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-notion-x": "^7.10.0"
+        "react-dom": "^18.3.1"
     },
     "devDependencies": {
         "@next/bundle-analyzer": "^14.2.35",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
 import "../styles/globals.css";
-import "react-notion-x/src/styles.css";
 
 function MyApp({ Component, pageProps }) {
     return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,58 +1,313 @@
-import React from "react";
 import Head from "next/head";
-import Image from "next/image";
-import Link from "next/link";
+import React from "react";
 
-import { NotionAPI } from "notion-client";
-import { NotionRenderer } from "react-notion-x";
+function Meta({ children }: { children: React.ReactNode }) {
+    return (
+        <p className="!mt-0 !mb-3 italic opacity-60 !text-base">{children}</p>
+    );
+}
 
-const notion = new NotionAPI();
+function ExtLink({
+    href,
+    children,
+}: {
+    href: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <a href={href} target="_blank" rel="noopener noreferrer">
+            {children}
+        </a>
+    );
+}
 
-export const getStaticProps = async (context) => {
-    const recordMap = await notion.getPage(process.env.PAGE_ID);
-    return {
-        props: {
-            recordMap,
-        },
-        revalidate: 10,
-    };
-};
-
-export default function NotionPage({ recordMap }) {
-    const [darkMode, setDarkMode] = React.useState(true);
-    React.useEffect(function () {
-        setDarkMode(
-            window?.matchMedia &&
-                window.matchMedia("(prefers-color-scheme: dark)").matches
-        );
-        window
-            .matchMedia("(prefers-color-scheme: dark)")
-            .addEventListener("change", (e) => setDarkMode(e.matches));
-        return () => {
-            window
-                .matchMedia("(prefers-color-scheme: dark)")
-                .removeEventListener("change", () => {});
-        };
-    }, []);
-
-    if (!recordMap) {
-        return null;
-    }
+export default function Home() {
     return (
         <>
             <Head>
-                <title>Tim's Site</title>
+                <title>Tim&apos;s Site</title>
+                <meta
+                    name="description"
+                    content="Timothy Samraj — Solutions Architect at AWS. Resume, side projects, and hackathons."
+                />
+                <meta property="og:title" content="Timothy Samraj" />
+                <meta
+                    property="og:description"
+                    content="Solutions Architect at AWS. Resume, side projects, and hackathons."
+                />
             </Head>
+            <div className="min-h-screen flex justify-center py-12">
+                <article className="prose dark:prose-invert md:prose-lg px-8 mx-auto">
+                    <h1>Timothy Samraj</h1>
+                    <blockquote>
+                        <p>
+                            Tim here. I&apos;m currently a Solutions Architect
+                            at Amazon Web Services (AWS).
+                        </p>
+                        <p>
+                            Here you&apos;ll find my unofficial resume, as well
+                            as links to some of my side projects and
+                            hackathons.
+                        </p>
+                    </blockquote>
 
-            <NotionRenderer
-                recordMap={recordMap}
-                fullPage={true}
-                darkMode={darkMode}
-                components={{
-                    nextImage: Image,
-                    nextLink: Link,
-                }}
-            />
+                    <h2>🔗 My Links</h2>
+                    <ul>
+                        <li>
+                            👨‍💻{" "}
+                            <ExtLink href="https://github.com/timTam97">
+                                GitHub ↗
+                            </ExtLink>
+                        </li>
+                        <li>
+                            💼{" "}
+                            <ExtLink href="https://www.linkedin.com/in/timothysamraj/">
+                                LinkedIn ↗
+                            </ExtLink>
+                        </li>
+                    </ul>
+
+                    <hr />
+
+                    <h2>🚀 (Some of) My Side Projects</h2>
+
+                    <h3>compcontrol-api</h3>
+                    <Meta>AWS CDK, TypeScript, Python</Meta>
+                    <p>
+                        An API that allows you to remotely control your
+                        computer.
+                    </p>
+                    <p>
+                        <ExtLink href="https://github.com/timTam97/compcontrol-api">
+                            GitHub Link ↗
+                        </ExtLink>
+                    </p>
+
+                    <h3>compcontrol-client</h3>
+                    <Meta>Haskell, Win32 API</Meta>
+                    <p>Remotely control your computer!</p>
+                    <p>
+                        This app runs on your PC and connects to the API
+                        mentioned above. It receives commands through a
+                        websocket connection and uses the Windows API to
+                        execute them.
+                    </p>
+                    <p>
+                        <ExtLink href="https://github.com/timTam97/compcontrol-client">
+                            GitHub Link ↗
+                        </ExtLink>
+                    </p>
+
+                    <h3>screenlapse</h3>
+                    <Meta>Python, AWS S3</Meta>
+                    <p>
+                        Takes a screenshot every few seconds and stitches a
+                        video together, creating a timelapse of your screen.
+                    </p>
+                    <p>
+                        <ExtLink href="https://github.com/timTam97/screenlapse">
+                            GitHub Link ↗
+                        </ExtLink>
+                    </p>
+
+                    <hr />
+
+                    <h2>👨‍💻 Work Experience</h2>
+
+                    <h3>Solutions Architect</h3>
+                    <Meta>
+                        <strong>Amazon Web Services</strong> (Feb 2022 -
+                        Present)
+                    </Meta>
+                    <p>
+                        I work with Public Sector customers to help them build
+                        scalable and resilient workloads that provide value to
+                        citizens and residents across Australia.
+                    </p>
+
+                    <h3>Solutions Architect Intern</h3>
+                    <Meta>
+                        <strong>Amazon Web Services</strong> (Dec 2020 - Feb
+                        2021)
+                    </Meta>
+                    <p>
+                        I received deep-dive training in modern infrastructure
+                        design and management. I built out multiple features on
+                        a major internal project and shadowed real-world
+                        customer interactions. During this time I picked up my
+                        SA Associate certification.
+                    </p>
+
+                    <h3>Programming Bootcamp Tutor</h3>
+                    <Meta>
+                        <strong>Monash University</strong> (Aug 2020)
+                    </Meta>
+                    <p>
+                        Assisted students who are new to programming in getting
+                        a head start before formal lectures.
+                    </p>
+
+                    <h3>Peer Mentor</h3>
+                    <Meta>
+                        <strong>Monash University</strong> (Jan 2020 - Jul
+                        2020, Feb 2021 - Jul 2021)
+                    </Meta>
+                    <p>
+                        Assisted new students in transitioning to university
+                        life by conducting weekly catch-ups and providing
+                        advice on courses and university.
+                    </p>
+
+                    <h3>Work Experience</h3>
+                    <Meta>
+                        <strong>
+                            CSIRO - High Performance Computing (HPC)
+                        </strong>{" "}
+                        (June 2016)
+                    </Meta>
+                    <p>
+                        I gained critical knowledge of research conducted in a
+                        scientific environment, as well as the teamwork and
+                        collaboration that are both crucial for success.
+                    </p>
+
+                    <hr />
+
+                    <h2>🛠 Skills &amp; Other Experience</h2>
+
+                    <h3>💻 Technology</h3>
+
+                    <h4>AWS &amp; Cloud</h4>
+                    <p>
+                        I possess strong knowledge of AWS and cloud computing.
+                        As a Solutions Architect at AWS, I dive deep into the
+                        platform and learn its ins and outs by facilitating
+                        customer engagements and building technical
+                        proof-of-concept demos.
+                    </p>
+                    <p>
+                        I am AWS Certified as a Solutions Architect Associate,
+                        Developer Associate and Cloud Practitioner.
+                    </p>
+
+                    <h4>TypeScript</h4>
+                    <p>
+                        Pretty much my language of choice now. I frequently use
+                        it at AWS, as well as in multiple personal frontend and
+                        backend projects.
+                    </p>
+                    <p>
+                        I also used TypeScript for my final year Computer
+                        Science project.
+                    </p>
+
+                    <h4>Python</h4>
+                    <p>
+                        Used in most of my core algorithm-based Computer
+                        Science units, as well as multiple personal projects.
+                    </p>
+
+                    <h4>C/C++ &amp; Java</h4>
+                    <p>
+                        Used in many core units at Uni. In addition to my
+                        general background with both languages, I&apos;ve got a
+                        little bit of experience with parallel computing in C,
+                        with libraries like OpenMP and OpenMPI.
+                    </p>
+
+                    <hr />
+
+                    <h2>⌨️ Hackathons</h2>
+
+                    <h3>Qube</h3>
+                    <Meta>
+                        <strong>Unihack 2022</strong> - Engineering Excellence
+                        Prize (April 2021)
+                    </Meta>
+                    <p>
+                        A mobile app to search, book, and virtually queue for
+                        doctor appointments, and a web platform for doctors to
+                        manage appointments.
+                    </p>
+                    <p>
+                        <ExtLink href="https://devpost.com/software/qube">
+                            Devpost Link ↗
+                        </ExtLink>
+                    </p>
+
+                    <h3>cleaner.io</h3>
+                    <Meta>
+                        <strong>Codebrew 2021</strong> - Winner in Public
+                        Health &amp; Best Tech (April 2021)
+                    </Meta>
+                    <p>
+                        A quick and secure way for cleaners of public transport
+                        to verify when they last cleaned the train, tram, or
+                        bus. Provides total transparency and assurance for
+                        passengers.
+                    </p>
+                    <p>
+                        <ExtLink href="https://devpost.com/software/cleaned">
+                            Devpost Link ↗
+                        </ExtLink>
+                    </p>
+
+                    <h3>SkyNet</h3>
+                    <Meta>
+                        <strong>Unihack 2021</strong> - Best Social Impact
+                        (March 2021)
+                    </Meta>
+                    <p>
+                        An easily deployable &amp; effective communication
+                        system for use after a natural disaster.
+                    </p>
+                    <p>
+                        <ExtLink href="https://devpost.com/software/skynet-ela2x3">
+                            Devpost Link ↗
+                        </ExtLink>
+                    </p>
+
+                    <h3>MediPlus</h3>
+                    <Meta>
+                        <strong>Codebrew 2020</strong> - Second place (August
+                        2020)
+                    </Meta>
+                    <p>
+                        An all-in-one solution for booking and managing
+                        appointments with your GP.
+                    </p>
+                    <p>
+                        <ExtLink href="https://github.com/timTam97/mediplus">
+                            GitHub Link ↗
+                        </ExtLink>
+                    </p>
+
+                    <h3>Séance Photo</h3>
+                    <Meta>
+                        <strong>Bit by Bit Hackathon 2019</strong> - Second
+                        place for First Time Hackers (August 2019)
+                    </Meta>
+                    <p>
+                        A platform for freelance photographers to promote and
+                        market their services.
+                    </p>
+                    <p>
+                        <ExtLink href="https://devpost.com/software/hireme">
+                            Devpost Link ↗
+                        </ExtLink>
+                    </p>
+
+                    <hr />
+
+                    <h2>📚 Education</h2>
+
+                    <h3>Bachelor&apos;s Degree in Computer Science</h3>
+                    <Meta>
+                        Monash University, Clayton (Partially complete - 2019
+                        - 2022)
+                    </Meta>
+                </article>
+            </div>
         </>
     );
 }


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @timTam97 :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Replaces the Notion-backed home page (`pages/index.tsx`) with a fully static React page that mirrors the existing Notion content.

## Changes

- **`pages/index.tsx`** — rewritten as a static page. Content (bio, links, side projects, work experience, skills, hackathons, education) is now plain JSX, styled with Tailwind `prose` to match the look of the existing markdown route. Two small inline helpers (`Meta`, `ExtLink`) keep the markup tidy. Source content was pulled from the Notion page (`PAGE_ID=Resume-113e4fe9f576406ba547f14ff99c7f75`) and translated 1:1.
- **Notion dependencies removed:** `@notionhq/client`, `notion-client`, `notion-utils`, `react-notion-x` (and the `react-notion-x/src/styles.css` import in `_app.tsx`).
- **`next.config.js`** — dropped the `PAGE_ID` env passthrough.
- **`CLAUDE.md`** — updated home-page description and removed `PAGE_ID` from required env vars.
- The other routes (`/[...name]` for markdown, `/files/[...name]` for PDFs) are untouched.

## Verification

- `npm install` clean (324 packages, no Notion deps).
- `npm run build` succeeds. The home page is now `○ (Static)` — prerendered at build time, no runtime fetch / ISR needed. First Load JS for `/` dropped to 88.8 kB.

## Notes

- The page intentionally does not include the Notion cover image or page icon. If you want them back, drop the assets into `public/` and reference them — happy to wire that up.
- TypeScript was renamed from "Typescript" → "TypeScript" in one place for consistency. No other content changes.
